### PR TITLE
Run coverage on `paypayopa/` rather than `tests/`

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -35,7 +35,7 @@ jobs:
         ./cc-test-reporter before-build
 
     - name: test script
-      run: pytest --cov=tests/ --cov-report xml
+      run: pytest --cov=paypayopa/ --cov-report xml
 
     # Run snyk test and use snyk-to-html to upload an artifact.
     - name: Install snyk

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -37,29 +37,6 @@ jobs:
     - name: test script
       run: pytest --cov=paypayopa/ --cov-report xml
 
-    # Run snyk test and use snyk-to-html to upload an artifact.
-    - name: Install snyk
-      run: npm install snyk
-
-    - name: Install snyk-to-html
-      run: npm install snyk-to-html
-
-    - name: snyk -v
-      run: ./node_modules/.bin/snyk -v
-    - name: snyk auth
-      run: ./node_modules/.bin/snyk auth ${{ secrets.SNYK_TOKEN }}
-    - name: snyk test
-      run: ./node_modules/.bin/snyk test --json --file=setup.py > snyk-test-results.json
-    - name: Generate snyk HTML results
-      if: always()
-      run: ./node_modules/.bin/snyk-to-html -d -i snyk-test-results.json -o snyk-test-results.html
-    - name: Upload snyk-test-results artifact
-      uses: actions/upload-artifact@v2
-      if: always()
-      with:
-        name: snyk-results
-        path: snyk-test-results.html
-
     - name: Coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR corrects the CI to run coverage on the source files rather than the tests.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](/contributing.md) document?
* [ ] Have you read and signed the automated Contributor's License Agreement?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
