### PR TITLE
Check if data has "orderItems" when create QR code

### DIFF
--- a/paypayopa/resources/code.py
+++ b/paypayopa/resources/code.py
@@ -27,19 +27,20 @@ class Code(Resource):
         if "currency" not in data["amount"]:
             raise ValueError("\x1b[31m MISSING REQUEST PARAMS"
                              " \x1b[0m for currency")
-        for item in data["orderItems"]:
-            if "name" not in item:
-                raise ValueError("\x1b[31m MISSING REQUEST PARAMS"
-                                 " \x1b[0m for orderItem Name")
-            if "quantity" not in item:
-                raise ValueError("\x1b[31m MISSING REQUEST PARAMS"
-                                 " \x1b[0m for orderItem quantity")
-            if "amount" not in item["unitPrice"]:
-                raise ValueError("\x1b[31m MISSING REQUEST PARAMS"
-                                 " \x1b[0m for orderItem.amount.unitPrice")
-            if "currency" not in item["unitPrice"]:
-                raise ValueError("\x1b[31m MISSING REQUEST PARAMS"
-                                 " \x1b[0m for orderItem.amount.currency")
+        if "orderItems" in data:
+            for item in data["orderItems"]:
+                if "name" not in item:
+                    raise ValueError("\x1b[31m MISSING REQUEST PARAMS"
+                                     " \x1b[0m for orderItem Name")
+                if "quantity" not in item:
+                    raise ValueError("\x1b[31m MISSING REQUEST PARAMS"
+                                     " \x1b[0m for orderItem quantity")
+                if "amount" not in item["unitPrice"]:
+                    raise ValueError("\x1b[31m MISSING REQUEST PARAMS"
+                                     " \x1b[0m for orderItem.amount.unitPrice")
+                if "currency" not in item["unitPrice"]:
+                    raise ValueError("\x1b[31m MISSING REQUEST PARAMS"
+                                     " \x1b[0m for orderItem.amount.currency")
         return self.post_url(url, data, api_id=API_NAMES.CREATE_QRCODE, **kwargs)
 
     def get_payment_details(self, id, **kwargs):


### PR DESCRIPTION
Fix `create qrcode` API to allow parameter without `orderItems`.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](/contributing.md) document?
* [ ] Have you read and signed the automated Contributor's License Agreement?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [ ] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
